### PR TITLE
Adding create-issue --parent option

### DIFF
--- a/module/redmine.js
+++ b/module/redmine.js
@@ -190,6 +190,7 @@ exports.createIssue = function(project, subject, options){
     if(options.priority)
       issue.issue.priority_id = exports.getPriorityIdByName(options.priority);
     if(options.assignee) issue.issue.assigned_to_id = options.assignee;
+    if(options.parent) issue.issue.parent_issue_id = options.parent;
     if(options.status)
       issue.issue.status_id = exports.getStatusIdByName(options.status);
     if(options.tracker)

--- a/program.js
+++ b/program.js
@@ -70,6 +70,7 @@ program
   .command('create-issue <project> <subject>')
   .description('Create a new issue.')
   .option('-P, --priority <priority>', 'Create with priority.')
+  .option('-p, --parent <parent_issue_id>', 'Create with parent task id.')
   .option('-a, --assignee <userId>', 'Create with assignee.')
   .option('-s, --status <status>', 'Create with status.')
   .option('-t, --tracker <tracker>', 'Create with tracker.')


### PR DESCRIPTION
This parameters allows users to specify the parent_issue_id so it will be created and assigned as a subtask of the (parent) task with a given id.