### PR TITLE
Generate issues command

### DIFF
--- a/issues-models/sample.json
+++ b/issues-models/sample.json
@@ -1,7 +1,4 @@
 {
-  // all properties are optional
-  // available properties are: 
-  //       assignee, description, estimated, parent, priority, status, subject and tracker
   "globals": {
     "priority": "Normal",
     "estimated": 1, 

--- a/issues-models/sample.json
+++ b/issues-models/sample.json
@@ -1,0 +1,22 @@
+{
+  // all properties are optional
+  // available properties are: 
+  //       assignee, description, estimated, parent, priority, status, subject and tracker
+  "globals": {
+    "priority": "Normal",
+    "estimated": 1, 
+    "assignee": 15,
+    "status": "New",
+    "tracker": "Task"
+  },
+  "issues": [{
+    "subject": "Peer review",
+    "description": "Follow instructions on wiki and review the last commit on designated branch."
+  },{
+    "subject": "Run tests",
+    "description": "Follow instructions on wiki and run tests on designated branch."
+  },{
+    "subject": "Notify developers",
+    "description": "If errors were detected, create issues for developers, following the wiki template."
+  }]
+}

--- a/module/actions.js
+++ b/module/actions.js
@@ -85,9 +85,10 @@ exports.handleRemoveModel = function (model){
   } catch(err){console.error(err)}
 }
 
-exports.handleListModels = function (model){
+exports.handleListModels = function (){
   try {
-    redmine.listModels();
+    var models = redmine.listModels();
+    console.log(models.join("\n"));
   } catch(err){console.error(err)}
 }
 

--- a/module/actions.js
+++ b/module/actions.js
@@ -70,6 +70,34 @@ exports.handleCreateIssue = function(project, subject, options){
   } catch(err){console.error(err)}
 }
 
+exports.handleImportModel = function (file_path, model, options){
+  try {
+    redmine.importModel(file_path, model, options);
+
+    console.log('Model successfully imported: ' + model);
+  } catch(err){console.error(err)}
+}
+
+exports.handleRemoveModel = function (model){
+  try {
+    redmine.removeModel(model);
+    console.log('Model successfully removed: ' + model);
+  } catch(err){console.error(err)}
+}
+
+exports.handleListModels = function (model){
+  try {
+    redmine.listModels();
+  } catch(err){console.error(err)}
+}
+
+exports.handleGenerateIssues = function(project, model, options){
+  try{
+    var issues = redmine.generateIssues(project, model, options);
+    console.log('Successfully generated issues ' + issues.join(', '));
+  } catch(err){console.error(err)}
+}
+
 exports.handleStatuses = function(options){
   try{
     var statuses = redmine.getStatuses();

--- a/module/redmine.js
+++ b/module/redmine.js
@@ -227,7 +227,6 @@ exports.importModel = function (filePath, model, options){
     var modelData = fs.readFileSync(filePath, encoding);
     var fd = fs.openSync(modelPath, "wx");
     fs.writeSync(fd, modelData, 0, encoding);
-
   } catch (err) {throw 'Could not import model:\n' + err}
 }
 
@@ -250,10 +249,13 @@ exports.listModels = function (){
     var path = require('path');
 
     var issuesModelPath = path.join(__dirname, '..', 'issues-models');
-    var models = fs.readdirSync(issuesModelPath);
+    const models = fs.readdirSync(issuesModelPath);
+    var result = [];
     for (var m in models)
-      console.log(models[m].replace('.json', ''));
+      result.push(models[m].replace('.json', ''));
     
+    return result;
+
   } catch (err) {throw 'Could not list models:\n' + err}
 }
 

--- a/module/redmine.js
+++ b/module/redmine.js
@@ -3,6 +3,8 @@ var nconf = require('nconf');
 var openInBrowser = require('open');
 var querystring = require('querystring');
 var resolver = require('./resolver.js');
+var fs = require('fs');
+var pth = require('path');
 
 nconf.file(__dirname + '/../config.json');
 
@@ -213,10 +215,7 @@ exports.createIssue = function(project, subject, options){
 
 exports.importModel = function (filePath, model, options){
   try {
-    var fs = require('fs');
-    var path = require('path');
-
-    var modelPath = path.join(__dirname, '..', 'issues-models', model + '.json');
+    var modelPath = pth.join(__dirname, '..', 'issues-models', model + '.json');
 
     if (fs.existsSync(modelPath) && !options.force)
       throw 'Model exists. Remove it first or use --force.'
@@ -232,10 +231,7 @@ exports.importModel = function (filePath, model, options){
 
 exports.removeModel = function (model){
   try {
-    var fs = require('fs');
-    var path = require('path');
-
-    var modelPath = path.join(__dirname, '..', 'issues-models', model + '.json');
+    var modelPath = pth.join(__dirname, '..', 'issues-models', model + '.json');
     if (!fs.existsSync(modelPath))
       throw 'Model not found.'
 
@@ -248,7 +244,7 @@ exports.listModels = function (){
     var fs = require('fs');
     var path = require('path');
 
-    var issuesModelPath = path.join(__dirname, '..', 'issues-models');
+    var issuesModelPath = pth.join(__dirname, '..', 'issues-models');
     const models = fs.readdirSync(issuesModelPath);
     var result = [];
     for (var m in models)
@@ -260,12 +256,9 @@ exports.listModels = function (){
 }
 
 exports.parseModel = function(model){
-  var fs = require('fs');
-  var path = require('path');
-
   try {
     // loading model JSON
-    var filePath = path.join(__dirname, '..', 'issues-models', model + '.json');
+    var filePath = pth.join(__dirname, '..', 'issues-models', model + '.json');
     var modelObject = JSON.parse(fs.readFileSync(filePath, 'utf8'));
 
     // model pre-validation

--- a/module/redmine.js
+++ b/module/redmine.js
@@ -211,6 +211,171 @@ exports.createIssue = function(project, subject, options){
   } catch(err) {throw 'Could not create issue:\n' + err}
 }
 
+exports.importModel = function (filePath, model, options){
+  try {
+    var fs = require('fs');
+    var path = require('path');
+
+    var modelPath = path.join(__dirname, '..', 'issues-models', model + '.json');
+
+    if (fs.existsSync(modelPath) && !options.force)
+      throw 'Model exists. Remove it first or use --force.'
+
+    var encoding = "utf8";
+    if (options.encoding) encoding = options.encoding;
+
+    var modelData = fs.readFileSync(filePath, encoding);
+    var fd = fs.openSync(modelPath, "wx");
+    fs.writeSync(fd, modelData, 0, encoding);
+
+  } catch (err) {throw 'Could not import model:\n' + err}
+}
+
+exports.removeModel = function (model){
+  try {
+    var fs = require('fs');
+    var path = require('path');
+
+    var modelPath = path.join(__dirname, '..', 'issues-models', model + '.json');
+    if (!fs.existsSync(modelPath))
+      throw 'Model not found.'
+
+    fs.unlinkSync(modelPath);
+  } catch (err) {throw 'Could not remove model:\n' + err}
+}
+
+exports.listModels = function (){
+  try {
+    var fs = require('fs');
+    var path = require('path');
+
+    var issuesModelPath = path.join(__dirname, '..', 'issues-models');
+    var models = fs.readdirSync(issuesModelPath);
+    for (var m in models)
+      console.log(models[m].replace('.json', ''));
+    
+  } catch (err) {throw 'Could not list models:\n' + err}
+}
+
+exports.parseModel = function(model){
+  var fs = require('fs');
+  var path = require('path');
+
+  try {
+    // loading model JSON
+    var filePath = path.join(__dirname, '..', 'issues-models', model + '.json');
+    var modelObject = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+
+    // model pre-validation
+    if (!modelObject)
+      throw 'Invalid JSON';
+
+    if (modelObject.issues instanceof Array == false)
+      throw 'Expected property `issues` (Array) on model';
+
+    if (modelObject.issues.length == 0)
+      throw 'Expected property `issues` (Array) containing at least 1 element on model';
+
+    if (typeof(modelObject.issues[0]) != "object")
+      throw 'Invalid property `issues` (Array<' + typeof(modelObject.issues[0]) + '>) on model. Expected Array<object>.';
+
+    if (typeof(modelObject.globals) != "object")
+      throw 'Invalid property `globals` (' + typeof(modelObject.globals) + ') on model. Expected object.';
+
+    // parsing globals
+    for (var p in modelObject.globals) {
+      for (var i in modelObject.issues) {
+        modelObject.issues[i][p] = modelObject.globals[p];
+      }
+    }
+
+    // model post-validation
+    for (var i in modelObject.issues) {
+        if (typeof(modelObject.issues[i].subject) != "string" || modelObject.issues[i].subject.length == 0)
+          throw 'Expected property `subject` in all issues' 
+    }
+    
+    
+    return modelObject.issues;
+  } catch(err) {throw 'Could not parse the model:\n' + err}
+}
+
+
+//TODO: rollback in case of error (delete issues that were created)
+exports.generateIssues = function(project, model, options){
+  throwWhenNotConnected();
+
+  var successIds = []
+
+  try{
+    // processing the model
+    var issuesModel = exports.parseModel(model);
+    for(var i in issuesModel){
+
+      // translating issuesModel properties to redmine API
+      var issue = {issue:{'project_id':project, 'subject': issuesModel[i].subject}};
+
+      // setting model properties
+      if(issuesModel[i].priority)
+        issue.issue.priority_id = exports.getStatusIdByName(issuesModel[i].priority);
+      if(issuesModel[i].assignee)
+        issue.issue.assigned_to_id = issuesModel[i].assignee;
+      if(issuesModel[i].parent)
+        issue.issue.parent_issue_id = issuesModel[i].parent;
+      if(issuesModel[i].estimated)
+        issue.issue.estimated_hours = issuesModel[i].estimated;
+      if(issuesModel[i].status)
+        issue.issue.status_id = exports.getStatusIdByName(issuesModel[i].status);
+      if(issuesModel[i].tracker)
+        issue.issue.tracker_id = exports.getTrackerIdByName(issuesModel[i].tracker);
+      if(issuesModel[i].description)
+        issue.issue.description = issuesModel[i].description;
+      
+      // overriding issuesModel options with command line options
+      if(options.priority)
+        issue.issue.priority_id = exports.getStatusIdByName(options.priority);
+      if(options.assignee)
+        issue.issue.assigned_to_id = options.assignee;
+      if(options.parent && typeof options.parent == 'string')
+        issue.issue.parent_issue_id = options.parent;
+      if(options.estimated)
+        issue.issue.estimated_hours = options.estimated;
+      if(options.status)
+        issue.issue.status_id = exports.getStatusIdByName(options.status);
+      if(options.tracker)
+        issue.issue.tracker_id = exports.getTrackerIdByName(options.tracker);
+      if(options.description && typeof options.description == 'string')
+        issue.issue.description = options.description;
+      if(options.subject)
+        issue.issue.subject = options.subject;
+
+      // creating issues
+      var response = post('/issues.json', issue);
+      var issue = JSON.parse(response.getBody('utf8'));
+      successIds.push(issue.issue.id);
+
+      if(response.statusCode == 404){
+        throw 'Server responded with statuscode 404.\n' +
+              'This is most likely the case when the specified project does not exist.\n' +
+              'Does project \''+ project +'\' exist?';
+      }
+      else if(response.statusCode != 201){
+        throw 'Server responded with statuscode ' + response.statusCode + '\n' +
+              'Model with error:\n' + modelObject.issues[i];
+      }
+    }
+
+    return successIds;
+  } catch(err) {
+    if (successIds.length > 0) {
+      throw 'Could not generate all issues. Issues created: ' + successIds.length.join(', ') + '. Error:\n' + err
+    }
+    else {
+      throw 'Could not generate any issue:\n' + err
+    }
+  }
+}
+
 exports.getStatuses = function(){
   throwWhenNotConnected();
 

--- a/module/redmine.js
+++ b/module/redmine.js
@@ -226,6 +226,7 @@ exports.importModel = function (filePath, model, options){
     var modelData = fs.readFileSync(filePath, encoding);
     var fd = fs.openSync(modelPath, "wx");
     fs.writeSync(fd, modelData, 0, encoding);
+    return true;
   } catch (err) {throw 'Could not import model:\n' + err}
 }
 
@@ -236,6 +237,7 @@ exports.removeModel = function (model){
       throw 'Model not found.'
 
     fs.unlinkSync(modelPath);
+    return true;
   } catch (err) {throw 'Could not remove model:\n' + err}
 }
 

--- a/module/redmine.js
+++ b/module/redmine.js
@@ -348,9 +348,6 @@ exports.generateIssues = function(project, model, options){
 
       // creating issues
       var response = post('/issues.json', issue);
-      var issue = JSON.parse(response.getBody('utf8'));
-      successIds.push(issue.issue.id);
-
       if(response.statusCode == 404){
         throw 'Server responded with statuscode 404.\n' +
               'This is most likely the case when the specified project does not exist.\n' +
@@ -358,14 +355,17 @@ exports.generateIssues = function(project, model, options){
       }
       else if(response.statusCode != 201){
         throw 'Server responded with statuscode ' + response.statusCode + '\n' +
-              'Model with error:\n' + modelObject.issues[i];
+              'Model with error:\n' + JSON.stringify(issuesModel[i]);
       }
+
+      var issue = JSON.parse(response.getBody('utf8'));
+      successIds.push(issue.issue.id);
     }
 
     return successIds;
   } catch(err) {
     if (successIds.length > 0) {
-      throw 'Could not generate all issues. Issues created: ' + successIds.length.join(', ') + '. Error:\n' + err
+      throw 'Could not generate all issues. Issues created: ' + successIds.join(', ') + '. Error:\n' + err
     }
     else {
       throw 'Could not generate any issue:\n' + err

--- a/program.js
+++ b/program.js
@@ -77,6 +77,67 @@ program
   .action(actions.handleCreateIssue);
 
 program
+  .command('import-model <file_path> <model>')
+  .description('Import the model file into redmine-cli for usage.')
+  .option('-f, --force', 'Overwrite the model if it exists.')
+  .option('-e, --encoding', 'Sets the file encoding (default: utf8).')
+  .action(actions.handleImportModel);
+
+program
+  .command('remove-model <model>')
+  .description('Remove the model from redmine-cli.')
+  .action(actions.handleRemoveModel);
+
+program
+  .command('list-models')
+  .description('Prints all issue models imported onto redmine-cli.')
+  .action(actions.handleListModels);
+
+program
+  .command('generate-issues <project> <model>')
+  .description('Generate a set of subtasks using a predefined model. You can set the options to override the model globals')
+  .option('-P, --priority <priority>', 'Create with priority.')
+  .option('-p, --parent <parent_issue_id>', 'Create with parent task id.')
+  .option('-e, --estimated <estimated_hours>', 'Create with estimated hours.')
+  .option('-a, --assignee <userId>', 'Create with assignee.')
+  .option('-s, --status <status>', 'Create with status.')
+  .option('-t, --tracker <tracker>', 'Create with tracker.')
+  .option('-d, --description <description>', 'Create with description.')
+  .action(actions.handleGenerateIssues).on('--help', function () {
+    console.log('  Usage example:');
+    console.log();
+    console.log('    Model saved at models/quality.json');
+    console.log();
+    console.log("    quality.json:");
+    console.log("    {");
+    console.log("      // all properties are optional");
+    console.log("      // available properties are:"); 
+    console.log("      //       assignee, description, estimated, parent, priority, status, subject and tracker");
+    console.log("      'globals': {");
+    console.log("        'priority': 'Normal',");
+    console.log("        'estimated': 1,"); 
+    console.log("        'assignee': 15,");
+    console.log("        'status': 'New',");
+    console.log("        'tracker': 'Task'");
+    console.log("      },");
+    console.log("      'issues': [{");
+    console.log("        'subject': 'Peer review',");
+    console.log("        'description': 'Follow instructions on wiki and review the last commit on designated branch.'");
+    console.log("      '},{");
+    console.log("        'subject': 'Run tests',");
+    console.log("        'description': 'Follow instructions on wiki and run tests on designated branch.'");
+    console.log("      '},{");
+    console.log("        'subject': 'Notify developers',");
+    console.log("        'description': 'If errors were detected, create issues for developers, following the wiki template.'");
+    console.log("      }]");
+    console.log("    }");
+    console.log();
+    console.log("    $ redmine generate-issues 15 quality --parent 371");
+    console.log("        This command would create 3 subtaks for issue 371 at project 15 using model quality.json.");
+  });
+
+
+program
   .command('statuses')
   .description('Display available issue statuses.')
   .action(actions.handleStatuses);

--- a/program.js
+++ b/program.js
@@ -97,43 +97,40 @@ program
   .command('generate-issues <project> <model>')
   .description('Generate a set of subtasks using a predefined model. You can set the options to override the model globals')
   .option('-P, --priority <priority>', 'Create with priority.')
-  .option('-p, --parent <parent_issue_id>', 'Create with parent task id.')
-  .option('-e, --estimated <estimated_hours>', 'Create with estimated hours.')
+  .option('-p, --parent <parentIssueId>', 'Create with parent task id.')
+  .option('-e, --estimated <estimatedHours>', 'Create with estimated hours.')
   .option('-a, --assignee <userId>', 'Create with assignee.')
   .option('-s, --status <status>', 'Create with status.')
   .option('-t, --tracker <tracker>', 'Create with tracker.')
   .option('-d, --description <description>', 'Create with description.')
   .action(actions.handleGenerateIssues).on('--help', function () {
     console.log('  Usage example:');
+    console.log('    $ redmine generate-issues 15 sample --parent 371');
+    console.log('        This command would create 3 subtaks for issue 371 at project 15 using model "sample".');
     console.log();
-    console.log('    Model saved at models/quality.json');
-    console.log();
-    console.log("    quality.json:");
-    console.log("    {");
-    console.log("      // all properties are optional");
-    console.log("      // available properties are:"); 
-    console.log("      //       assignee, description, estimated, parent, priority, status, subject and tracker");
-    console.log("      'globals': {");
-    console.log("        'priority': 'Normal',");
-    console.log("        'estimated': 1,"); 
-    console.log("        'assignee': 15,");
-    console.log("        'status': 'New',");
-    console.log("        'tracker': 'Task'");
-    console.log("      },");
-    console.log("      'issues': [{");
-    console.log("        'subject': 'Peer review',");
-    console.log("        'description': 'Follow instructions on wiki and review the last commit on designated branch.'");
-    console.log("      '},{");
-    console.log("        'subject': 'Run tests',");
-    console.log("        'description': 'Follow instructions on wiki and run tests on designated branch.'");
-    console.log("      '},{");
-    console.log("        'subject': 'Notify developers',");
-    console.log("        'description': 'If errors were detected, create issues for developers, following the wiki template.'");
-    console.log("      }]");
-    console.log("    }");
-    console.log();
-    console.log("    $ redmine generate-issues 15 quality --parent 371");
-    console.log("        This command would create 3 subtaks for issue 371 at project 15 using model quality.json.");
+    console.log('    model "sample":');
+    console.log('    {');
+    console.log('      // all properties are optional');
+    console.log('      // available properties are:'); 
+    console.log('      //       assignee, description, estimated, parent, priority, status, subject and tracker');
+    console.log('      "globals": {');
+    console.log('        "priority": "Normal,');
+    console.log('        "estimate"": 1,'); 
+    console.log('        "assignee": 15,');
+    console.log('        "status": "New",');
+    console.log('        "tracker": "Task"');
+    console.log('      },');
+    console.log('      "issues": [{');
+    console.log('        "subject": "Peer review",');
+    console.log('        "description": "Follow instructions on wiki and review the last commit on designated branch."');
+    console.log('      },{');
+    console.log('        "subject": "Run tests",');
+    console.log('        "description": "Follow instructions on wiki and run tests on designated branch."');
+    console.log('      },{');
+    console.log('        "subject": "Notify developers",');
+    console.log('        "description": "If errors were detected, create issues for developers, following the wiki template."');
+    console.log('      }]');
+    console.log('    }');
   });
 
 

--- a/spec/actions-spec.js
+++ b/spec/actions-spec.js
@@ -201,6 +201,87 @@ describe('actions.js', function() {
     expect(console.error).toHaveBeenCalledWith('error');
   });
 
+  it("should handle import model", function() {
+    var options = {options: []}; 
+
+    spyOn(redmine, 'importModel').andReturn();
+    spyOn(console, 'log');
+
+    actions.handleImportModel("sample.json", "sample", options);
+
+    expect(redmine.importModel).toHaveBeenCalledWith("sample.json", "sample", options);
+    expect(console.log).toHaveBeenCalledWith('Model successfully imported: sample');
+  });
+
+  it("should handle import model and catch error", function() {
+    spyOn(redmine, 'importModel').andThrow('error');
+    spyOn(console, 'error');
+
+    actions.handleImportModel();
+
+    expect(console.error).toHaveBeenCalledWith('error');
+  });
+
+  it("should handle remove model", function() {
+    spyOn(redmine, 'removeModel').andReturn();
+    spyOn(console, 'log');
+
+    actions.handleRemoveModel("sample");
+
+    expect(redmine.removeModel).toHaveBeenCalledWith("sample");
+    expect(console.log).toHaveBeenCalledWith('Model successfully removed: sample');
+  });
+
+  it("should handle remove model and catch error", function() {
+    spyOn(redmine, 'removeModel').andThrow('error');
+    spyOn(console, 'error');
+
+    actions.handleRemoveModel();
+
+    expect(console.error).toHaveBeenCalledWith('error');
+  });
+
+  it("should handle list models", function() {
+    spyOn(redmine, 'listModels').andReturn(["sample"]);
+    spyOn(console, 'log');
+
+    actions.handleListModels();
+
+    expect(redmine.listModels).toHaveBeenCalledWith();
+    expect(console.log).toHaveBeenCalledWith('sample');
+  });
+
+  it("should handle list models and catch error", function() {
+    spyOn(redmine, 'listModels').andThrow('error');
+    spyOn(console, 'error');
+
+    actions.handleListModels();
+
+    expect(console.error).toHaveBeenCalledWith('error');
+  });
+
+  it("should handle generate issues", function() {
+    var options = {options:[]};
+    var result = [1,2,3];
+
+    spyOn(redmine, 'generateIssues').andReturn(result);
+    spyOn(console, 'log');
+
+    actions.handleGenerateIssues("project", "model", options);
+
+    expect(redmine.generateIssues).toHaveBeenCalledWith("project", "model", options);
+    expect(console.log).toHaveBeenCalledWith('Successfully generated issues ' + result.join(", "));
+  });
+
+  it("should handle generate issues and catch error", function() {
+    spyOn(redmine, 'generateIssues').andThrow('error');
+    spyOn(console, 'error');
+
+    actions.handleGenerateIssues();
+
+    expect(console.error).toHaveBeenCalledWith('error');
+  });
+
   it("should handle statuses", function() {
     var statuses = {statuses: []};
 

--- a/spec/redmine-spec.js
+++ b/spec/redmine-spec.js
@@ -269,6 +269,24 @@ describe('redmine.js', function() {
       .toThrow('Could not create issue:\nServer responded with statuscode 500');
   });
 
+  it("should list models", function() {
+    var expected = "sample";
+    var fs = redmine.__get__('fs');
+    spyOn(fs, 'readdirSync').andReturn([expected + ".json"]);
+    
+    var actual = redmine.listModels();
+
+    expect(actual).toEqual([expected]);
+  });
+
+  it("should list models and return error", function() {
+    var fs = redmine.__get__('fs');
+    spyOn(fs, 'readdirSync').andCallFake(function() {
+      throw 'Folder issues-models not found.'
+    });
+    
+    expect(redmine.listModels).toThrow('Could not list models:\nFolder issues-models not found.');
+  });
 
   it("should get statuses", function() {
     var statuses = {issue_statuses: []};

--- a/spec/redmine-spec.js
+++ b/spec/redmine-spec.js
@@ -336,6 +336,30 @@ describe('redmine.js', function() {
     expect(function() {redmine.importModel("", "", {});}).toThrow("Could not import model:\nModel exists. Remove it first or use --force.");
   });
 
+  it("should remove model", function() {
+    var pth = redmine.__get__('pth');
+    spyOn(pth, 'join').andReturn("/some/path");
+
+    var fs = redmine.__get__('fs');
+    spyOn(fs, 'existsSync').andReturn(true);
+    spyOn(fs, 'unlinkSync').andReturn();
+    
+    var actual = redmine.removeModel("");
+
+    expect(actual).toEqual(true);
+  });
+
+  it("should remove model and return error", function() {
+    var pth = redmine.__get__('pth');
+    spyOn(pth, 'join').andReturn("/some/path");
+
+    var fs = redmine.__get__('fs');
+    spyOn(fs, 'existsSync').andReturn(false);
+    spyOn(fs, 'unlinkSync').andReturn();
+
+    expect(redmine.removeModel).toThrow("Could not remove model:\nModel not found.");
+  });
+
   it("should get statuses", function() {
     var statuses = {issue_statuses: []};
     var response = { getBody : function(){return JSON.stringify(statuses)}};

--- a/spec/redmine-spec.js
+++ b/spec/redmine-spec.js
@@ -272,6 +272,8 @@ describe('redmine.js', function() {
   it("should list models", function() {
     var expected = "sample";
     var fs = redmine.__get__('fs');
+    var pth = redmine.__get__('pth');
+    spyOn(pth, 'join').andReturn("");
     spyOn(fs, 'readdirSync').andReturn([expected + ".json"]);
     
     var actual = redmine.listModels();
@@ -280,12 +282,58 @@ describe('redmine.js', function() {
   });
 
   it("should list models and return error", function() {
+    var pth = redmine.__get__('pth');
+    spyOn(pth, 'join').andReturn("/some/path");
+
     var fs = redmine.__get__('fs');
     spyOn(fs, 'readdirSync').andCallFake(function() {
       throw 'Folder issues-models not found.'
     });
     
     expect(redmine.listModels).toThrow('Could not list models:\nFolder issues-models not found.');
+  });
+
+  it("should import model", function() {
+    var pth = redmine.__get__('pth');
+    spyOn(pth, 'join').andReturn("/some/path");
+
+    var fs = redmine.__get__('fs');
+    spyOn(fs, 'existsSync').andReturn(false);
+    spyOn(fs, 'readFileSync').andReturn();
+    spyOn(fs, 'openSync').andReturn();
+    spyOn(fs, 'writeSync').andReturn();
+    
+    var actual = redmine.importModel("", "", {});
+
+    expect(actual).toEqual(true);
+  });
+
+  it("should import model with force", function() {
+    var pth = redmine.__get__('pth');
+    spyOn(pth, 'join').andReturn("/some/path");
+
+    var fs = redmine.__get__('fs');
+    spyOn(fs, 'existsSync').andReturn(true);
+    spyOn(fs, 'readFileSync').andReturn();
+    spyOn(fs, 'openSync').andReturn();
+    spyOn(fs, 'writeSync').andReturn();
+    
+    var actual = redmine.importModel("", "", {force: true});
+
+    expect(actual).toEqual(true);
+  });
+
+  it("should import model and return error", function() {
+    var pth = redmine.__get__('pth');
+    spyOn(pth, 'join').andReturn("/some/path");
+
+    var fs = redmine.__get__('fs');
+    spyOn(fs, 'existsSync').andReturn(true);
+    spyOn(fs, 'readFileSync').andReturn();
+    spyOn(fs, 'openSync').andReturn();
+    spyOn(fs, 'writeSync').andReturn();
+
+    expect(function() {redmine.imporModel("", "", {});}).toThrow();
   });
 
   it("should get statuses", function() {

--- a/spec/redmine-spec.js
+++ b/spec/redmine-spec.js
@@ -360,6 +360,131 @@ describe('redmine.js', function() {
     expect(redmine.removeModel).toThrow("Could not remove model:\nModel not found.");
   });
 
+  it("should parse model", function() {
+    var pth = redmine.__get__('pth');
+    spyOn(pth, 'join').andReturn("/some/path");
+
+    var fs = redmine.__get__('fs');
+    spyOn(fs, 'readFileSync').andReturn("");
+
+    spyOn(JSON, 'parse').andReturn({
+      globals: {
+        assignee: 1
+      },
+      issues: [{
+        subject: "Test",
+        description: "Test"
+      },{
+        subject: "Test",
+        description: "Test"
+      }] 
+    });
+    
+    var actual = redmine.parseModel("");
+
+    expect(actual).toEqual([{
+      assignee: 1,
+      subject: "Test",
+      description: "Test"
+    },{
+      assignee: 1,
+      subject: "Test",
+      description: "Test"
+    }]);
+  });
+
+  it("should parse model and return error Invalid JSON", function() {
+    var pth = redmine.__get__('pth');
+    spyOn(pth, 'join').andReturn("/some/path");
+
+    var fs = redmine.__get__('fs');
+    spyOn(fs, 'readFileSync').andReturn("");
+
+    spyOn(JSON, 'parse').andReturn(null);
+
+    expect(redmine.parseModel).toThrow('Could not parse the model:\nInvalid JSON');
+  });
+
+  it("should parse model and return error Expected property issues on model", function() {
+    var pth = redmine.__get__('pth');
+    spyOn(pth, 'join').andReturn("/some/path");
+
+    var fs = redmine.__get__('fs');
+    spyOn(fs, 'readFileSync').andReturn("");
+
+    spyOn(JSON, 'parse').andReturn({
+      globals: {
+        assignee: 1
+      } 
+    });
+
+    expect(redmine.parseModel).toThrow('Could not parse the model:\nExpected property `issues` (Array) on model');
+  });
+
+  it("should parse model and return error Expected property issues containing at least 1 item", function() {
+    var pth = redmine.__get__('pth');
+    spyOn(pth, 'join').andReturn("/some/path");
+
+    var fs = redmine.__get__('fs');
+    spyOn(fs, 'readFileSync').andReturn("");
+
+    spyOn(JSON, 'parse').andReturn({
+      globals: {
+        assignee: 1
+      },
+      issues: []
+    });
+
+    expect(redmine.parseModel).toThrow('Could not parse the model:\nExpected property `issues` (Array) containing at least 1 element on model');
+  });
+
+  it("should parse model and return error Expected property issues of type Array<object>", function() {
+    var pth = redmine.__get__('pth');
+    spyOn(pth, 'join').andReturn("/some/path");
+
+    var fs = redmine.__get__('fs');
+    spyOn(fs, 'readFileSync').andReturn("");
+
+    spyOn(JSON, 'parse').andReturn({
+      globals: {
+        assignee: 1
+      },
+      issues: ['error']
+    });
+
+    expect(redmine.parseModel).toThrow('Could not parse the model:\nInvalid property `issues` (Array<string>) on model. Expected Array<object>.');
+  });
+
+  it("should parse model and return error Expected property globals of type object", function() {
+    var pth = redmine.__get__('pth');
+    spyOn(pth, 'join').andReturn("/some/path");
+
+    var fs = redmine.__get__('fs');
+    spyOn(fs, 'readFileSync').andReturn("");
+
+    spyOn(JSON, 'parse').andReturn({
+      globals: '',
+      issues: [{}]
+    });
+
+    expect(redmine.parseModel).toThrow('Could not parse the model:\nInvalid property `globals` (string) on model. Expected object.');
+  });
+
+  it("should parse model and return error Expected property subject in all issues", function() {
+    var pth = redmine.__get__('pth');
+    spyOn(pth, 'join').andReturn("/some/path");
+
+    var fs = redmine.__get__('fs');
+    spyOn(fs, 'readFileSync').andReturn("");
+
+    spyOn(JSON, 'parse').andReturn({
+      globals: {},
+      issues: [{}]
+    });
+
+    expect(redmine.parseModel).toThrow('Could not parse the model:\nExpected property `subject` in all issues');
+  });
+
   it("should get statuses", function() {
     var statuses = {issue_statuses: []};
     var response = { getBody : function(){return JSON.stringify(statuses)}};

--- a/spec/redmine-spec.js
+++ b/spec/redmine-spec.js
@@ -303,7 +303,7 @@ describe('redmine.js', function() {
     spyOn(fs, 'openSync').andReturn();
     spyOn(fs, 'writeSync').andReturn();
     
-    var actual = redmine.importModel("", "", {});
+    var actual = redmine.importModel("", "", {encoding: "iso-8859-1"});
 
     expect(actual).toEqual(true);
   });
@@ -333,7 +333,7 @@ describe('redmine.js', function() {
     spyOn(fs, 'openSync').andReturn();
     spyOn(fs, 'writeSync').andReturn();
 
-    expect(function() {redmine.imporModel("", "", {});}).toThrow();
+    expect(function() {redmine.importModel("", "", {});}).toThrow("Could not import model:\nModel exists. Remove it first or use --force.");
   });
 
   it("should get statuses", function() {


### PR DESCRIPTION
Hi again!

I finally took some time to finish this implementation.

I created a new command called `generate-issues` that takes 2 parameters, `<project>` and `<model>`. The main objective of this command is to generate a set of issues from a predefined JSON model.

A common use case is:
- Suppose there is a task #37, subject: "Implement some feature"
- For this task we have a known set of subtasks like:
  - Define interfaces
  - Write unit tests
  - Write code to pass unit tests
  - Refactor code

We would then define a model called `TDD.json` like this:
```json
{
    "globals": {
        "assignee": 1,
        "tracker": "Task"
    },
    "issues": [
        {"subject": "Define interfaces"},
        {"subject": "Write unit tests"},
        {"subject": "Write code to pass unit tests"},
        {"subject": "Refactor code"}
    ]
}
```

Then we would import the model into RedmineCLI: `redmine import-model <path_to_TDD.json> TDD`.

Finally we would generate the subtasks for the assigned parent issue: `redmine generate-issues <project> TDD --parent 37`.

Aside from `generate-issues` and `import-model`, there are also `list-models` and `remove-model` commands to provide all possible use-cases regarding model management. 

I hope you like this new feature. It's proven to be very useful for me.